### PR TITLE
Fixed tone for secondaryContainer for dark theme

### DIFF
--- a/typescript/scheme/scheme.ts
+++ b/typescript/scheme/scheme.ts
@@ -168,7 +168,7 @@ export class Scheme {
       onPrimaryContainer: core.a1.tone(10),
       secondary: core.a2.tone(80),
       onSecondary: core.a2.tone(20),
-      secondaryContainer: core.a2.tone(70),
+      secondaryContainer: core.a2.tone(30),
       onSecondaryContainer: core.a2.tone(10),
       tertiary: core.a3.tone(80),
       onTertiary: core.a3.tone(20),


### PR DESCRIPTION
The tone for `secondaryContainer` is different according to the design kit.
![image](https://user-images.githubusercontent.com/14848874/141394226-bf8a807f-c4f0-4c9c-8960-f8a365339046.png)
