### PR TITLE
Rename HCT to Hct

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -15,10 +15,10 @@ for more information.
 `npm i @material/material-color-utilities` or `yarn add @material/material-color-utilities`
 
 ```typescript
-import { HCT } from "@material/material-color-utilities";
+import { Hct } from "@material/material-color-utilities";
 
 // Simple demonstration of HCT.
-const color = HCT.fromInt(0xff4285f4);
+const color = Hct.fromInt(0xff4285f4);
 console.log(`Hue: ${color.hue}`);
 console.log(`Chrome: ${color.chroma}`);
 console.log(`Tone: ${color.tone}`);


### PR DESCRIPTION
Import package name correctly.

https://github.com/zmaplex/material-color-utilities/blob/605ea9e25153986df6b9984145813309fe838394/typescript/hct/hct.ts#L45

This repo is not *currently* accepting external contributions, but feature
requests and bug reports are very welcome!
