### PR TITLE
Fix Swift Package

### DIFF
--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version: 5.8
+
 // Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// swift-tools-version: 5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Package.swift is not compatible with swift package manifest.

swift tools version declaration must be on top of the file.

<img width="899" alt="CleanShot 2023-05-19 at 13 47 40@2x" src="https://github.com/material-foundation/material-color-utilities/assets/1888355/1ee69205-67cc-4dc5-8c37-5f71d1d26551">
