### PR TITLE
cpp: add missing includes (fixes gcc build)

### DIFF
--- a/cpp/scheme/scheme_content.cc
+++ b/cpp/scheme/scheme_content.cc
@@ -16,6 +16,8 @@
 
 #include "cpp/scheme/scheme_content.h"
 
+#include <cmath>
+
 #include "cpp/cam/hct.h"
 #include "cpp/dislike/dislike.h"
 #include "cpp/dynamiccolor/dynamic_scheme.h"

--- a/cpp/scheme/scheme_fidelity.cc
+++ b/cpp/scheme/scheme_fidelity.cc
@@ -16,6 +16,8 @@
 
 #include "cpp/scheme/scheme_fidelity.h"
 
+#include <cmath>
+
 #include "cpp/cam/hct.h"
 #include "cpp/dislike/dislike.h"
 #include "cpp/dynamiccolor/dynamic_scheme.h"

--- a/cpp/temperature/temperature_cache.h
+++ b/cpp/temperature/temperature_cache.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <vector>
+#include <optional>
 
 #include "cpp/cam/hct.h"
 


### PR DESCRIPTION
This fixes building material-color-utilities with gcc.

I know it says this repo is not currently accepting contributions; feel free to close this and add the three lines yourself. It was just than an issue (I can do that too if desired though).

cc maintainers (I hope these are right): @cushon @kluever