### PR TITLE
Make Hct.toInt() public

### DIFF
--- a/swift/Sources/MaterialColorUtilities/Hct/Hct.swift
+++ b/swift/Sources/MaterialColorUtilities/Hct/Hct.swift
@@ -115,7 +115,7 @@ public class Hct: Equatable, Hashable {
     return Hct(argb)
   }
 
-  func toInt() -> Int {
+  public func toInt() -> Int {
     return _argb
   }
 


### PR DESCRIPTION
The `toInt()` method of `Hct`, which returns the RGBA representation only has package visibility, where as it's other properties (e.g `hue`, `chroma`, and `tone`) are `public`. This means that when consuming this repo as a SPM dependency it's possible to create a `Hct` value from an RGBA value and modify it, but it's not possible to convert it back to an RGBA value.

This repo is not *currently* accepting external contributions, but feature
requests and bug reports are very welcome!
